### PR TITLE
Add missing std includes

### DIFF
--- a/lib/rendering/rndr/RenderTimingRecord.h
+++ b/lib/rendering/rndr/RenderTimingRecord.h
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <stddef.h>
 #include <float.h>
+#include <limits>
 
 // This directive makes to keep all passes timing record in memory for debugging purpose.
 // If this is on, memory for record timing result will increase on demand. This might cause problem if

--- a/lib/rendering/rt/gpu/GPUPrimitive.h
+++ b/lib/rendering/rt/gpu/GPUPrimitive.h
@@ -8,6 +8,7 @@
 
 #include <cuda.h>
 #include <vector>
+#include <array>
 
 namespace moonray {
 namespace rt {

--- a/lib/rendering/shading/bsdf/hair/BsdfHairOneSampler.h
+++ b/lib/rendering/shading/bsdf/hair/BsdfHairOneSampler.h
@@ -15,6 +15,8 @@
 #include <scene_rdl2/common/math/Vec2.h>
 #include <scene_rdl2/common/math/Vec3.h>
 
+#include <array>
+
 namespace moonray {
 namespace shading {
 

--- a/tests/lib/common/mcrt_util/test_aligned_element_array.cc
+++ b/tests/lib/common/mcrt_util/test_aligned_element_array.cc
@@ -6,6 +6,7 @@
 #include <moonray/common/mcrt_util/AlignedElementArray.h>
 
 #include <numeric>
+#include <cstdint>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestAlignedElementArray);
 


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build):  build
Jira ticket: na
Release Notes Comment:  Fix build errors due to missing std includes

Special Notes: Currently fails to build with newer compilers, need to add in the includes for some of the standard library types used.

Look or Scene Setup Change: No
