### PR TITLE
Switch from deprecated tbb::mutex to std::mutex

### DIFF
--- a/dso/map/Image/ImageMap.cc
+++ b/dso/map/Image/ImageMap.cc
@@ -84,8 +84,8 @@ ImageMap::ImageMap(const scene_rdl2::rdl2::SceneClass &sceneClass, const std::st
     // to allow for the possibility that we may someday create these maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
     sStaticImageMapData.sErrorInvalidUdimCoord =
         mLogEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/dso/map/UsdUVTexture/UsdUVTexture.cc
+++ b/dso/map/UsdUVTexture/UsdUVTexture.cc
@@ -53,8 +53,8 @@ UsdUVTexture::UsdUVTexture(const scene_rdl2::rdl2::SceneClass &sceneClass, const
     // to allow for the possibility that we may someday create these maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
     sStaticUsdUVTextureData.sErrorInvalidUdimCoord =
         mLogEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/lib/common/mcrt_util/MutexPool2D.h
+++ b/lib/common/mcrt_util/MutexPool2D.h
@@ -8,8 +8,6 @@
 #include <scene_rdl2/common/platform/Platform.h>
 #include <scene_rdl2/render/util/BitUtils.h>
 
-#include <tbb/mutex.h>
-
 namespace moonray {
     constexpr int getMutexCount(int log2MutexCount)
     {
@@ -55,7 +53,7 @@ namespace moonray {
     }
 #endif
 
-    template <int sLog2MutexCount, typename MutexType = tbb::mutex>
+    template <int sLog2MutexCount, typename MutexType = std::mutex>
     class MutexPool2D
     {
     public:

--- a/lib/common/mcrt_util/ProcessStats.h
+++ b/lib/common/mcrt_util/ProcessStats.h
@@ -8,12 +8,11 @@
 #include <scene_rdl2/common/platform/Platform.h>
 #include <scene_rdl2/render/logging/logging.h>
 
-#include <tbb/mutex.h>
-
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <string>
+#include <mutex>
 
 namespace moonray {
 namespace util {
@@ -49,9 +48,9 @@ private:
     // ifstream mutex to prevent corrupt reads
     // when we are getting log messages from
     // threaded sections of code
-    mutable tbb::mutex mMemoryReadMutex;
-    mutable tbb::mutex mReadIOMutex;
-    mutable tbb::mutex mSystemUtilMutex;
+    mutable std::mutex mMemoryReadMutex;
+    mutable std::mutex mReadIOMutex;
+    mutable std::mutex mSystemUtilMutex;
 
 };
 

--- a/lib/rendering/bvh/shading/AttributeKey.cc
+++ b/lib/rendering/bvh/shading/AttributeKey.cc
@@ -8,7 +8,7 @@ using namespace scene_rdl2;
 namespace moonray {
 namespace shading {
 
-tbb::mutex AttributeKey::sRegisterMutex;
+std::mutex AttributeKey::sRegisterMutex;
 std::vector<std::string> AttributeKey::sKeyNames;
 std::vector<AttributeType> AttributeKey::sKeyTypes;
 std::vector<size_t> AttributeKey::sKeySizes;

--- a/lib/rendering/bvh/shading/AttributeKey.h
+++ b/lib/rendering/bvh/shading/AttributeKey.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <scene_rdl2/scene/rdl2/Types.h>
-#include <tbb/mutex.h>
 #include <unordered_set>
 #include <map>
 
@@ -87,7 +86,7 @@ protected:
     static finline bool hasDerivatives(AttributeKey key);
 
 private:
-    static tbb::mutex sRegisterMutex;
+    static std::mutex sRegisterMutex;
     static std::vector<std::string> sKeyNames;
     static std::vector<AttributeType> sKeyTypes;
     static std::vector<size_t> sKeySizes;
@@ -269,7 +268,7 @@ AttributeKey::requestDerivatives() const
         return false;
     }
     {
-        tbb::mutex::scoped_lock lock(sRegisterMutex);
+        std::scoped_lock lock(sRegisterMutex);
         sHasDerivatives[mIndex] = 1;
     }
     return true;
@@ -302,7 +301,7 @@ AttributeKey::insertKey(const std::string &name, bool requestDerivatives)
     std::pair<std::string, AttributeType> lookup(name, type);
     int index = -1;
     {
-        tbb::mutex::scoped_lock lock(sRegisterMutex);
+        std::scoped_lock lock(sRegisterMutex);
         auto it = sTable.find(lookup);
         if (it == sTable.end()) {
             index = static_cast<int>(sKeyNames.size());

--- a/lib/rendering/bvh/shading/ShadingTLState.cc
+++ b/lib/rendering/bvh/shading/ShadingTLState.cc
@@ -3,7 +3,6 @@
 
 #include "ShadingTLState.h"
 #include <moonray/common/mcrt_macros/moonray_static_check.h>
-#include <tbb/mutex.h>
 
 namespace ispc {
 extern "C" uint32_t ShadingTLState_hudValidation(bool);
@@ -33,7 +32,7 @@ struct Private
 };
 
 Private gPrivate;
-tbb::mutex gInitMutex;
+std::mutex gInitMutex;
 
 void
 initPrivate(const mcrt_common::TLSInitParams &initParams)
@@ -97,7 +96,7 @@ TLState::allocTls(mcrt_common::ThreadLocalState *tls,
 {
     {
         // Protect against races the very first time we initialize gPrivate.
-        tbb::mutex::scoped_lock lock(gInitMutex);
+        std::scoped_lock lock(gInitMutex);
 
         if (gPrivate.mRefCount == 0) {
             texture::TLState::initPrivate(initParams);

--- a/lib/rendering/mcrt_common/Util.cc
+++ b/lib/rendering/mcrt_common/Util.cc
@@ -4,10 +4,10 @@
 //
 #include "Util.h"
 #include <execinfo.h>  // backtrace
-#include <tbb/mutex.h>
 #include <sys/syscall.h>
 
 #include <cstring>
+#include <mutex>
 
 namespace moonray {
 namespace mcrt_common {
@@ -38,7 +38,7 @@ debugPrintThreadID(const char *contextString)
 void
 debugPrintCallstack(const char *contextString)
 {
-    static tbb::mutex mutex;
+    static std::mutex mutex;
 
     mutex.lock();
 

--- a/lib/rendering/pbr/core/Cryptomatte.cc
+++ b/lib/rendering/pbr/core/Cryptomatte.cc
@@ -96,7 +96,7 @@ void CryptomatteBuffer::addSampleVector(unsigned x, unsigned y, float sampleId, 
                                         bool incrementSamples)
 {
     // Lock in case multiple threads want to add samples to this pixel
-    tbb::mutex::scoped_lock lock(mPixelMutexes[getMutexIdx(x, y)]);
+    std::scoped_lock lock(mPixelMutexes[getMutexIdx(x, y)]);
 
     PixelEntry &pixelEntry = mPixelEntries[CRYPTOMATTE_TYPE_REGULAR][y * mWidth + x];
 

--- a/lib/rendering/pbr/core/Cryptomatte.h
+++ b/lib/rendering/pbr/core/Cryptomatte.h
@@ -9,7 +9,6 @@
 #include <scene_rdl2/scene/rdl2/RenderOutput.h>
 
 #include <list>
-#include <tbb/mutex.h>
 #include <vector>
 
 namespace moonray {
@@ -202,7 +201,7 @@ private:
  */
     static const int mMutexTileSize = 15;
     // force mutex to be cache-line aligned for speed
-    struct CACHE_ALIGN AlignedMutex : public tbb::mutex {};
+    struct CACHE_ALIGN AlignedMutex : public std::mutex {};
     AlignedMutex *mPixelMutexes;
     int getMutexIdx(unsigned x, unsigned y) const {
         return (y % mMutexTileSize) * mMutexTileSize + (x % mMutexTileSize);

--- a/lib/rendering/pbr/core/DeepBuffer.cc
+++ b/lib/rendering/pbr/core/DeepBuffer.cc
@@ -351,7 +351,7 @@ DeepBuffer::addSample8x8Safe(unsigned x, unsigned y, unsigned subpixelX, unsigne
                              float scale, float weight)
 {
     // Lock in case multiple threads want to add samples to this pixel
-    tbb::mutex::scoped_lock lock(mPixelMutex[getMutexIdx(x, y)]);
+    std::scoped_lock lock(mPixelMutex[getMutexIdx(x, y)]);
 
     addSample8x8(x, y, subpixelX, subpixelY, layer, ids, t, rayZ, normal, alpha,
                  channels, numChannels, values, scale, weight);

--- a/lib/rendering/pbr/core/DeepBuffer.h
+++ b/lib/rendering/pbr/core/DeepBuffer.h
@@ -13,7 +13,6 @@
 #include <moonray/deepfile/DcxChannelSet.h>
 #include <moonray/deepfile/DcxDeepImageTile.h>
 #include <OpenEXR/ImfHeader.h>
-#include <tbb/mutex.h>
 
 namespace moonray {
 
@@ -420,7 +419,7 @@ private:
  */
     static const int mMutexTileSize = 15;
     // force mutex to be cache-line aligned for speed
-    struct CACHE_ALIGN AlignedMutex : public tbb::mutex {};
+    struct CACHE_ALIGN AlignedMutex : public std::mutex {};
     AlignedMutex *mPixelMutex;
     int getMutexIdx(unsigned x, unsigned y) const {
         return (y % mMutexTileSize) * mMutexTileSize + (x % mMutexTileSize);

--- a/lib/rendering/rndr/Film.h
+++ b/lib/rendering/rndr/Film.h
@@ -213,7 +213,7 @@ public:
     // updating statistics in vector mode.
     void addSampleStatisticsSafe(unsigned px, unsigned py, std::size_t idx, const float* aovs)
     {
-        tbb::mutex::scoped_lock lock(mStatsMutex.getMutex(px, py));
+        std::scoped_lock lock(mStatsMutex.getMutex(px, py));
         addSampleStatistics(px, py, idx, aovs);
     }
 

--- a/lib/rendering/rndr/RenderDriver.h
+++ b/lib/rendering/rndr/RenderDriver.h
@@ -28,6 +28,7 @@
 #include <scene_rdl2/render/util/AtomicFloat.h>
 
 #include <tbb/task_scheduler_init.h>
+#include <tbb/spin_mutex.h>
 
 //#define SINGLE_THREAD_CRAWLALLPIXELS
 

--- a/lib/rendering/shading/BasicTexture.cc
+++ b/lib/rendering/shading/BasicTexture.cc
@@ -99,8 +99,8 @@ public:
         // to allow for the possibility that we may someday create image maps
         // on multiple threads, we'll protect the writes of the class statics
         // with a mutex.
-        static tbb::mutex errorMutex;
-        tbb::mutex::scoped_lock lock(errorMutex);
+        static std::mutex errorMutex;
+        std::scoped_lock lock(errorMutex);
         MOONRAY_START_THREADSAFE_STATIC_WRITE
 
         mIspc.mBasicTextureStaticDataPtr = &sBasicTextureStaticData;

--- a/lib/rendering/shading/Material.h
+++ b/lib/rendering/shading/Material.h
@@ -167,14 +167,14 @@ protected:
     // We will also get warned when executing this codepath at render time via
     // the logger so if it becomes a common case, we need to revisit and remove
     // these locks and heap allocations.
-    tbb::mutex              mDeferredEntryMutex;
+    std::mutex              mDeferredEntryMutex;
     std::vector<SortedRayState> mDeferredEntries;
 
-    static tbb::mutex       sMaterialListMutex;
+    static std::mutex       sMaterialListMutex;
     static MaterialPtrList  sAllMaterials;
     static MaterialPtrList  sQueuelessMaterials;
 
-    static tbb::mutex       sShadeQueueMutex;
+    static std::mutex       sShadeQueueMutex;
     static ShadeQueueList   sShadeQueues;
 
     // This is used by the flushNonEmptyShadeQueue function to iterate through all queues

--- a/lib/rendering/shading/UdimTexture.cc
+++ b/lib/rendering/shading/UdimTexture.cc
@@ -19,7 +19,6 @@
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
-#include <tbb/mutex.h>
 
 #include <dirent.h>
 #include <unordered_set>
@@ -121,8 +120,8 @@ public:
         // to allow for the possibility that we may someday create image maps
         // on multiple threads, we'll protect the writes of the class statics
         // with a mutex.
-        static tbb::mutex errorMutex;
-        tbb::mutex::scoped_lock lock(errorMutex);
+        static std::mutex errorMutex;
+        std::scoped_lock lock(errorMutex);
         MOONRAY_START_THREADSAFE_STATIC_WRITE
 
         mIspc.mUdimTextureStaticDataPtr = &sUdimTextureStaticData;
@@ -251,7 +250,7 @@ public:
         mIspc.mIs8bit = mIs8bit;
 
         mIspc.mIsValid = true;
-        tbb::mutex errorMutex;
+        std::mutex errorMutex;
 
         tbb::blocked_range<int> range(0, mTextureHandleIndices.size());
         tbb::parallel_for(range, [&] (const tbb::blocked_range<int> &r) {

--- a/lib/rendering/texturing/sampler/TextureSampler.cc
+++ b/lib/rendering/texturing/sampler/TextureSampler.cc
@@ -466,7 +466,7 @@ TextureSampler::registerMapForInvalidation(const std::string &fileName, scene_rd
 {
 
     // Textures could be loaded in parallel, use mutex to avoid data race.
-    tbb::recursive_mutex::scoped_lock lock(mMutex);
+    std::scoped_lock lock(mMutex);
     
     OIIO::ustring oiioFileName(fileName);
 
@@ -492,7 +492,7 @@ TextureSampler::registerMapForInvalidation(const std::string &fileName, scene_rd
 void
 TextureSampler::unregisterMapForInvalidation(scene_rdl2::rdl2::Shader *map)
 {
-    tbb::recursive_mutex::scoped_lock lock(mMutex);
+    std::scoped_lock lock(mMutex);
     MNRY_ASSERT(isValid());
 
     auto mapRange = mShaderToName.equal_range(map);

--- a/lib/rendering/texturing/sampler/TextureSampler.h
+++ b/lib/rendering/texturing/sampler/TextureSampler.h
@@ -11,8 +11,6 @@
 #include <scene_rdl2/common/grid_util/Parser.h>
 #include <scene_rdl2/common/math/Color.h>
 
-#include <tbb/recursive_mutex.h>
-
 // system
 #include <string>
 #include <set>
@@ -137,7 +135,7 @@ protected:
     // For the udim case, a single ImageMap may reference multiple texture files.
     std::multimap<scene_rdl2::rdl2::Shader *, OIIO::ustring> mShaderToName;
 
-    tbb::recursive_mutex mMutex;
+    std::recursive_mutex mMutex;
 
     Parser mParser;
 };

--- a/lib/rendering/texturing/sampler/TextureTLState.cc
+++ b/lib/rendering/texturing/sampler/TextureTLState.cc
@@ -4,7 +4,6 @@
 #include "TextureSampler.h"
 #include "TextureTLState.h"
 #include <moonray/common/mcrt_macros/moonray_static_check.h>
-#include <tbb/mutex.h>
 
 namespace ispc {
 extern "C" uint32_t TextureTLState_hudValidation(bool);


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build):  build
Jira ticket: na
Release Notes Comment:  

Special Notes: Changes away from tbb::mutex to the std::mutex as it has been deprecated and removed in tbb 2021+

Look or Scene Setup Change: No

