### PR TITLE
Switch from deprecated tbb::atomic to std::atomic

### DIFF
--- a/lib/rendering/geom/Procedural.cc
+++ b/lib/rendering/geom/Procedural.cc
@@ -14,8 +14,6 @@
 #include <moonray/rendering/geom/PrimitiveGroup.h>
 #include <moonray/rendering/geom/PrimitiveVisitor.h>
 
-#include <tbb/atomic.h>
-
 #include <numeric>
 
 namespace moonray {
@@ -25,7 +23,7 @@ class PrimitiveMemoryAccumulator : public PrimitiveVisitor
 {
 public:
     PrimitiveMemoryAccumulator(
-            tbb::atomic<Primitive::size_type>& usage,
+            std::atomic<Primitive::size_type>& usage,
             SharedPrimitiveSet& sharedPrimitives,
             bool inPrimitiveGroup = false) :
         mUsage(usage), mSharedPrimitives(sharedPrimitives),
@@ -63,7 +61,7 @@ public:
     }
 
 private:
-    tbb::atomic<Primitive::size_type>& mUsage;
+    std::atomic<Primitive::size_type>& mUsage;
     SharedPrimitiveSet& mSharedPrimitives;
     bool mInPrimitiveGroup;
 };
@@ -123,7 +121,7 @@ private:
 Procedural::size_type
 Procedural::getMemory()
 {
-    tbb::atomic<Primitive::size_type> usage {0u};
+    std::atomic<Primitive::size_type> usage {0u};
     SharedPrimitiveSet sharedPrimitives;
     PrimitiveMemoryAccumulator accumulator(usage, sharedPrimitives);
     forEachPrimitive(accumulator);

--- a/lib/rendering/geom/Procedural.h
+++ b/lib/rendering/geom/Procedural.h
@@ -30,11 +30,18 @@ struct GeometryStatistics {
     GeometryStatistics(): mFaceCount {0}, mMeshVertexCount {0},
         mCurvesCount {0}, mCVCount {0}, mInstanceCount {0} {}
 
-    tbb::atomic<Primitive::size_type> mFaceCount;
-    tbb::atomic<Primitive::size_type> mMeshVertexCount;
-    tbb::atomic<Primitive::size_type> mCurvesCount;
-    tbb::atomic<Primitive::size_type> mCVCount;
-    tbb::atomic<Primitive::size_type> mInstanceCount;
+    GeometryStatistics(const GeometryStatistics &other): 
+        mFaceCount(other.mFaceCount.load()),
+        mMeshVertexCount(other.mMeshVertexCount.load()),
+        mCurvesCount(other.mCurvesCount.load()),
+        mCVCount(other.mCVCount.load()),
+        mInstanceCount(other.mInstanceCount.load()) {}
+
+    std::atomic<Primitive::size_type> mFaceCount;
+    std::atomic<Primitive::size_type> mMeshVertexCount;
+    std::atomic<Primitive::size_type> mCurvesCount;
+    std::atomic<Primitive::size_type> mCVCount;
+    std::atomic<Primitive::size_type> mInstanceCount;
 };
 
 //----------------------------------------------------------------------------

--- a/lib/rendering/mcrt_common/Bundle.h
+++ b/lib/rendering/mcrt_common/Bundle.h
@@ -210,7 +210,7 @@ protected:
         return unsigned(entriesToFlush);
     }
 
-    tbb::atomic<uint32_t>   mQueueSize;   // must not exceed mMaxEntries
+    std::atomic<uint32_t>   mQueueSize;   // must not exceed mMaxEntries
     uint32_t                mMaxEntries;
     EntryType *             mEntries;     // all data offsets are relative to this address
     Handler                 mHandler;
@@ -502,7 +502,7 @@ protected:
         return unsigned(entriesToFlush);
     }
 
-    tbb::atomic<uint32_t>   mQueueSize;   // must not exceed mMaxEntries
+    std::atomic<uint32_t>   mQueueSize;   // must not exceed mMaxEntries
     uint32_t                mMaxEntries;
     EntryType *             mEntries;     // all data offsets are relative to this address
     Handler                 mHandler;
@@ -788,7 +788,7 @@ protected:
         return unsigned(entriesToFlush);
     }
 
-    tbb::atomic<uint32_t>       mQueueSize;   // must not exceed mMaxEntries
+    std::atomic<uint32_t>       mQueueSize;   // must not exceed mMaxEntries
     uint32_t                    mMaxEntries;
     EntryType *                 mEntries;     // all data offsets are relative to this address
     Handler                     mHandler;

--- a/lib/rendering/mcrt_common/ThreadLocalState.cc
+++ b/lib/rendering/mcrt_common/ThreadLocalState.cc
@@ -42,7 +42,7 @@ namespace
 {
 
 // Counter to hand out unique indices to TLSProxy objects.
-tbb::atomic<unsigned> gNextFrameUpdateTLSIndex;
+std::atomic<unsigned> gNextFrameUpdateTLSIndex;
 
 // These are lightweight objects which we put into a tbb::enumerable_thread_specific
 // container so that we can map OS thread ids to consistent top level ThreadLocalState
@@ -50,7 +50,7 @@ tbb::atomic<unsigned> gNextFrameUpdateTLSIndex;
 struct FrameUpdateTLSProxy
 {
     FrameUpdateTLSProxy() :
-        mTLSIndex(gNextFrameUpdateTLSIndex.fetch_and_increment())
+        mTLSIndex(gNextFrameUpdateTLSIndex++)
     {
     }
 

--- a/lib/rendering/pbr/Types.h
+++ b/lib/rendering/pbr/Types.h
@@ -12,7 +12,6 @@
 #include <scene_rdl2/common/math/Vec3.h>
 #include <scene_rdl2/common/math/Vec4.h>
 
-#include <tbb/atomic.h>
 #include <vector>
 
 

--- a/lib/rendering/pbr/Types.hh
+++ b/lib/rendering/pbr/Types.hh
@@ -155,7 +155,7 @@ enum OcclTestType
 
 
 #define DEEP_DATA_MEMBERS                                               \
-    HUD_CPP_MEMBER(tbb::atomic<int>, mRefCount, 4);                     \
+    HUD_CPP_MEMBER(std::atomic<int>, mRefCount, 4);                     \
     HUD_MEMBER(uint32_t, mHitDeep);                                     \
     HUD_MEMBER(float, mSubpixelX);                                      \
     HUD_MEMBER(float, mSubpixelY);                                      \
@@ -182,7 +182,7 @@ enum OcclTestType
 
 
 #define CRYPTOMATTE_DATA_MEMBERS                                    \
-    HUD_CPP_MEMBER(tbb::atomic<int>, mRefCount, 4);                 \
+    HUD_CPP_MEMBER(std::atomic<int>, mRefCount, 4);                 \
     HUD_CPP_PTR(pbr::CryptomatteBuffer*, mCryptomatteBuffer);       \
     HUD_MEMBER(uint32_t, mHit);                                     \
     HUD_MEMBER(uint32_t, mPrevPresence);                            \
@@ -211,7 +211,7 @@ enum OcclTestType
 // bytes in size due to them being allocated as one cache line.
 
 #define CRYPTOMATTE_DATA_MEMBERS_2                                  \
-    HUD_CPP_MEMBER(tbb::atomic<int>, mRefCount, 4);                 \
+    HUD_CPP_MEMBER(std::atomic<int>, mRefCount, 4);                 \
     HUD_MEMBER(HVD_NAMESPACE(scene_rdl2::math, Vec3f), mRefP);      \
     HUD_MEMBER(HVD_NAMESPACE(scene_rdl2::math, Vec3f), mRefN);      \
     HUD_MEMBER(HVD_NAMESPACE(scene_rdl2::math, Vec2f), mUV)

--- a/lib/rendering/pbr/core/PbrTLState.cc
+++ b/lib/rendering/pbr/core/PbrTLState.cc
@@ -58,8 +58,8 @@ MNRY_STATIC_ASSERT(ALLOC_LIST_MAX_NUM_ITEMS <=
                   ((ALLOC_LIST_INFO_BITS >> ALLOC_LIST_INFO_BIT_SHIFT) + 1));
 
 // Per frame counter, gets reset each frame.
-CACHE_ALIGN tbb::atomic<unsigned> gFailedRayStateAllocs;
-CACHE_ALIGN tbb::atomic<unsigned> gFailedCL1Allocs;
+CACHE_ALIGN std::atomic<unsigned> gFailedRayStateAllocs;
+CACHE_ALIGN std::atomic<unsigned> gFailedCL1Allocs;
 
 // For memory profiling, see DEBUG_RECORD_PEAK_RAYSTATE_USAGE.
 unsigned MAYBE_UNUSED gPeakRayStateUsage = 0;
@@ -416,7 +416,7 @@ TLState::poolAlloc(const char * const typeName,
                    unsigned numEntries,
                    ResType **entries,
                    OverlappedAccType accumStall,
-                   tbb::atomic<unsigned> &numFailedAllocs)
+                   std::atomic<unsigned> &numFailedAllocs)
 {
     // 99.9999% case, allocation should succeed.
     bool success = pool.allocList(numEntries, entries);

--- a/lib/rendering/pbr/core/PbrTLState.h
+++ b/lib/rendering/pbr/core/PbrTLState.h
@@ -196,7 +196,7 @@ private:
                            unsigned numEntries,
                            ResType **entries,
                            OverlappedAccType accumStall,
-                           tbb::atomic<unsigned> &numFailedAlloc);
+                           std::atomic<unsigned> &numFailedAlloc);
 
     DISALLOW_COPY_OR_ASSIGNMENT(TLState);
 };

--- a/lib/rendering/rndr/RenderFramePasses.cc
+++ b/lib/rendering/rndr/RenderFramePasses.cc
@@ -103,8 +103,8 @@ RenderDriver::renderPasses(RenderDriver *driver, const FrameState &fs,
 
     // This counter verifies that we don't leave this function until all threads
     // have started working.
-    CACHE_ALIGN tbb::atomic<unsigned> numTBBThreads;
-    CACHE_ALIGN tbb::atomic<bool> canceled;
+    CACHE_ALIGN std::atomic<unsigned> numTBBThreads;
+    CACHE_ALIGN std::atomic<bool> canceled;
 
     numTBBThreads = 0;
     canceled = false;

--- a/lib/rendering/rndr/RenderStatistics.cc
+++ b/lib/rendering/rndr/RenderStatistics.cc
@@ -963,24 +963,24 @@ RenderStats::logGeometryUsage(const geom::GeometryStatistics& totalGeomStatistic
 
     for(std::size_t i = 0; i < geomStateInfo.size(); ++i) {
         geomTable.emplace_back(geomStateInfo[i].first,
-           geomStateInfo[i].second.mFaceCount,
-           geomStateInfo[i].second.mMeshVertexCount,
-           geomStateInfo[i].second.mCurvesCount,
-           geomStateInfo[i].second.mCVCount,
-           geomStateInfo[i].second.mInstanceCount);
+           geomStateInfo[i].second.mFaceCount.load(),
+           geomStateInfo[i].second.mMeshVertexCount.load(),
+           geomStateInfo[i].second.mCurvesCount.load(),
+           geomStateInfo[i].second.mCVCount.load(),
+           geomStateInfo[i].second.mInstanceCount.load());
     }
 
     StatsTable<2> summaryTable("Geometry Statistics Summary");
     summaryTable.emplace_back("Total Face Count",
-        totalGeomStatistics.mFaceCount);
+        totalGeomStatistics.mFaceCount.load());
     summaryTable.emplace_back("Total Mesh Vertex Count",
-        totalGeomStatistics.mMeshVertexCount);
+        totalGeomStatistics.mMeshVertexCount.load());
     summaryTable.emplace_back("Total Curves Count",
-        totalGeomStatistics.mCurvesCount);
+        totalGeomStatistics.mCurvesCount.load());
     summaryTable.emplace_back("Total Curves CV Count",
-        totalGeomStatistics.mCVCount);
+        totalGeomStatistics.mCVCount.load());
     summaryTable.emplace_back("Total Instance Count",
-        totalGeomStatistics.mInstanceCount);
+        totalGeomStatistics.mInstanceCount.load());
 
     auto writeCSV = [&](std::ostream& outs, bool athenaFormat) {
         outs.precision(2);

--- a/lib/rendering/rt/EmbreeAccelerator.cc
+++ b/lib/rendering/rt/EmbreeAccelerator.cc
@@ -41,7 +41,7 @@ namespace rt {
 
 
 typedef tbb::concurrent_unordered_map<std::shared_ptr<geom::SharedPrimitive>,
-        tbb::atomic<bool>, geom::SharedPtrHash> SharedSceneMap;
+        std::atomic<bool>, geom::SharedPtrHash> SharedSceneMap;
 
 
 class BVHBuilder : public geom::PrimitiveVisitor

--- a/lib/rendering/rt/GeometryManager.cc
+++ b/lib/rendering/rt/GeometryManager.cc
@@ -1361,7 +1361,7 @@ GeometryManager::getEmissiveRegions(const scene_rdl2::rdl2::Layer* layer,
 }
 
 // Counter to provide unique thread ids
-tbb::atomic<unsigned> gThreadIdCounter;
+std::atomic<unsigned> gThreadIdCounter;
 
 GeometryManager::GM_RESULT
 GeometryManager::tessellate(scene_rdl2::rdl2::Layer* layer,
@@ -1396,7 +1396,7 @@ GeometryManager::tessellate(scene_rdl2::rdl2::Layer* layer,
     struct ThreadID {
         // When we create a ThreadID, the counter increments and so
         // each thread gets a unique human readable id.
-        ThreadID() : mId(gThreadIdCounter.fetch_and_increment()){}
+        ThreadID() : mId(gThreadIdCounter++){}
         unsigned mId;
     };
     typedef tbb::enumerable_thread_specific< ThreadID > EnumerableThreadID;

--- a/lib/rendering/rt/GeometryManager.h
+++ b/lib/rendering/rt/GeometryManager.h
@@ -38,7 +38,7 @@ namespace rt {
 
 enum class ChangeFlag;
 
-typedef tbb::concurrent_unordered_map<geom::internal::Primitive *, tbb::atomic<unsigned int>> PrimitiveReferenceCountMap;
+typedef tbb::concurrent_unordered_map<geom::internal::Primitive *, std::atomic<unsigned int>> PrimitiveReferenceCountMap;
 
 struct GeometryManagerStats
 {
@@ -187,7 +187,7 @@ public:
 
     finline void compareAndSwapFlag(ChangeFlag swapFlag, ChangeFlag compareFlag)
     {
-        mChangeStatus.compare_and_swap(swapFlag, compareFlag);
+        mChangeStatus.compare_exchange_strong(swapFlag, compareFlag);
     }
 
     void updateGPUAccelerator(const scene_rdl2::rdl2::Layer* layer);
@@ -255,7 +255,7 @@ private:
 
     GeometryManagerOptions mOptions;
 
-    typedef tbb::atomic<ChangeFlag> ChangeFlagAtomic;
+    typedef std::atomic<ChangeFlag> ChangeFlagAtomic;
 
     /// Tracks current change status
     ChangeFlagAtomic mChangeStatus;

--- a/lib/rendering/rt/gpu/GPUAcceleratorImpl.h
+++ b/lib/rendering/rt/gpu/GPUAcceleratorImpl.h
@@ -23,7 +23,7 @@ namespace rt {
 
 // Also in EmbreeAccelerator.cc
 typedef tbb::concurrent_unordered_map<std::shared_ptr<geom::SharedPrimitive>,
-        tbb::atomic<GPUPrimitiveGroup*>, geom::SharedPtrHash> SharedGroupMap;
+        std::atomic<GPUPrimitiveGroup*>, geom::SharedPtrHash> SharedGroupMap;
 
 
 class GPUAcceleratorImpl

--- a/lib/rendering/shading/Material.cc
+++ b/lib/rendering/shading/Material.cc
@@ -15,10 +15,10 @@ MaterialPtrList Material::sQueuelessMaterials;
 tbb::mutex Material::sShadeQueueMutex;
 ShadeQueueList Material::sShadeQueues;
 
-tbb::atomic<size_t> Material::sFlushCycleIdx;
+std::atomic<size_t> Material::sFlushCycleIdx;
 
-tbb::atomic<uint32_t> Material::sDeferredEntryCalls;
-tbb::atomic<uint32_t> Material::sTotalDeferredEntries;
+std::atomic<uint32_t> Material::sDeferredEntryCalls;
+std::atomic<uint32_t> Material::sTotalDeferredEntries;
 
 Material::Material(const scene_rdl2::rdl2::SceneObject & owner) :
     RootShader(owner),

--- a/lib/rendering/shading/Material.h
+++ b/lib/rendering/shading/Material.h
@@ -180,11 +180,11 @@ protected:
     // This is used by the flushNonEmptyShadeQueue function to iterate through all queues
     // in a cyclic fashion as opposed to starting the iteration at the beginning of the
     // queue list each time.
-    static tbb::atomic<size_t> sFlushCycleIdx;
+    static std::atomic<size_t> sFlushCycleIdx;
 
     // Shared between all Materials.
-    static tbb::atomic<uint32_t> sDeferredEntryCalls;
-    static tbb::atomic<uint32_t> sTotalDeferredEntries;
+    static std::atomic<uint32_t> sDeferredEntryCalls;
+    static std::atomic<uint32_t> sTotalDeferredEntries;
 };
 
 template <typename Body>

--- a/tests/lib/rendering/pbr/TestLights.cc
+++ b/tests/lib/rendering/pbr/TestLights.cc
@@ -271,7 +271,7 @@ testLightPDF(const Vec3f &p, const Vec3f &n, const LightTester *lightTester,
     // compute ref pdfs (only for unit test debugging)
     //
 
-    tbb::atomic<unsigned> refValidSampleCount;
+    std::atomic<unsigned> refValidSampleCount;
     refValidSampleCount = 0;
 
     double refPdf = doReductionOverUnitSquare<double>(0.0,
@@ -326,7 +326,7 @@ testLightPDF(const Vec3f &p, const Vec3f &n, const LightTester *lightTester,
     // compute test pdf
     //
 
-    tbb::atomic<unsigned> testValidSampleCount;
+    std::atomic<unsigned> testValidSampleCount;
     testValidSampleCount = 0;
 
     double testPdf = doReductionOverUnitSquare<double>(0.0,
@@ -394,7 +394,7 @@ testLightPDF(const Vec3f &p, const Vec3f &n, const LightTester *lightTester,
     // compute test pdf of ISPC light
     //
 
-    tbb::atomic<unsigned> testIspcValidSampleCount;
+    std::atomic<unsigned> testIspcValidSampleCount;
     testIspcValidSampleCount = 0;
 
     double testIspcPdf = doReductionOverUnitSquare<double>(0.0,
@@ -525,7 +525,7 @@ testLightCanIlluminate(const Vec3f &, const Vec3f &, const LightTester *lightTes
     // Test C++ light implementation
     //
 
-    tbb::atomic<int32_t> seed;
+    std::atomic<int32_t> seed;
     seed = initialSeed;
 
     tbb::parallel_for(tbb::blocked_range<unsigned>(0, NUM_CAN_ILLUMINATE_TESTS,
@@ -651,11 +651,11 @@ testLightIntersection(const Vec3f &p, const Vec3f &n, const LightTester *lightTe
     // Test C++ implementation
     //
 
-    tbb::atomic<unsigned> cppIsectsEqual;
+    std::atomic<unsigned> cppIsectsEqual;
     cppIsectsEqual = 0;
-    tbb::atomic<unsigned> cppNoIntersection;
+    std::atomic<unsigned> cppNoIntersection;
     cppNoIntersection = 0;
-    tbb::atomic<unsigned> cppInvalidSamples;
+    std::atomic<unsigned> cppInvalidSamples;
     cppInvalidSamples = 0;
 
     tbb::parallel_for (tbb::blocked_range<unsigned>(0u, NUM_SAMPLES_PER_AXIS, GRAINSIZE_PER_AXIS),
@@ -780,11 +780,11 @@ testLightIntersection(const Vec3f &p, const Vec3f &n, const LightTester *lightTe
     // Test ISPC implementation
     //
 
-    tbb::atomic<unsigned> ispcIsectsEqual;
+    std::atomic<unsigned> ispcIsectsEqual;
     ispcIsectsEqual = 0;
-    tbb::atomic<unsigned> ispcNoIntersection;
+    std::atomic<unsigned> ispcNoIntersection;
     ispcNoIntersection = 0;
-    tbb::atomic<unsigned> ispcInvalidSamples;
+    std::atomic<unsigned> ispcInvalidSamples;
     ispcInvalidSamples = 0;
 
     tbb::parallel_for (tbb::blocked_range<unsigned>(0u, NUM_SAMPLES_PER_AXIS, GRAINSIZE_PER_AXIS),


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build): build
Jira ticket: na
Release Notes Comment:

Special Notes: Changes away from tbb::atomic to the std::atomic as it has been deprecated and removed in tbb 2021+. Not 100% sure on the changes to and around GeometryStatistics but it seems to work.

Look or Scene Setup Change: No

