### PR TITLE
Change from tbb:task_scheduler to tbb::global_control

### DIFF
--- a/lib/rendering/rndr/RenderDriver.h
+++ b/lib/rendering/rndr/RenderDriver.h
@@ -27,7 +27,7 @@
 #include <scene_rdl2/common/grid_util/Parser.h>
 #include <scene_rdl2/render/util/AtomicFloat.h>
 
-#include <tbb/task_scheduler_init.h>
+#include <tbb/global_control.h>
 
 //#define SINGLE_THREAD_CRAWLALLPIXELS
 
@@ -766,7 +766,7 @@ private:
     std::unique_ptr<TileScheduler>  mTileSchedulerCheckpointInitEstimation;
     TileWorkQueue       mTileWorkQueue;
 
-    tbb::task_scheduler_init *mTaskScheduler;
+    tbb::global_control *mTaskScheduler;
 
     // The is the per film sample count, NOT the cumulative sample count over
     // all films.

--- a/tests/lib/rendering/pbr/TestLightSetSampler.cc
+++ b/tests/lib/rendering/pbr/TestLightSetSampler.cc
@@ -23,8 +23,6 @@
 #include <scene_rdl2/common/math/Math.h>
 #include <scene_rdl2/render/util/Arena.h>
 
-#include <tbb/task_scheduler_init.h>
-
 
 // to iterate over the [0, 1)^2 space we take (NUM_SAMPLES_PER_AXIS * NUM_SAMPLES_PER_AXIS) samples
 #define NUM_SAMPLES_PER_AXIS                1000


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build): build
Jira ticket: na
Release Notes Comment:

Special Notes: Changes away from tbb::task_scheduler to the std::global_control as it has been deprecated and removed in tbb 2021+. It is probably better to switch to using a task_arena but this seemed like the easier, most drop in solution for now.

Look or Scene Setup Change: No

