### PR TITLE
Fix oob access of mLightAccList in updateLightList

### DIFF
--- a/lib/rendering/pbr/core/Scene.cc
+++ b/lib/rendering/pbr/core/Scene.cc
@@ -727,7 +727,7 @@ Scene::updateLightList()
     }
 
     // Reserve memory for the light accelerators
-    mLightAccList.reserve(lightSetCount + 1);
+    mLightAccList.resize(lightSetCount + 1);
 
     // Create mapping from rdl2 assignment ids to runtime light sets and light accelerators
     mIdToLightSetMap.reserve(assignmentCount);


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build): build
Jira ticket: N/A.
Release Notes Comment: Fix out of bounds access of `mLightAccList` in `Scene::updateLightList`.

Special Notes: N/A.

Look or Scene Setup Change: No

# Reviewers
N/A.

# Pull request comments
Fixes an oob assertion check in `Scene::updateLightList` when accessing a cleaned `mLightAccList`, reserving space for a `std::vector` does not set its size if it is zero, so `mLightAccList.resize` should be used instead.

# Rats test images
N/A.

# Documentation (link)
N/A.

# Unit Test Reminder
N/A.
